### PR TITLE
Restrict api results #45

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -370,6 +370,12 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 			configValue{Key: ConfigVotingEnabled, Default: DefaultVotingEnabled, Type: ConfigBool},
 			configValue{Key: ConfigMaxUserVotes, Default: DefaultMaxUserVotes, Type: ConfigInt},
 			configValue{Key: ConfigEntriesRequireApproval, Default: DefaultEntriesRequireApproval, Type: ConfigBool},
+
+			configValue{Key: ConfigAutofillEnabled, Default: DefaultAutofillEnabled, Type: ConfigBool},
+			configValue{Key: ConfigJikanEnabled, Default: DefaultJikanEnabled, Type: ConfigBool},
+			configValue{Key: ConfigJikanBannedTypes, Default: DefaultJikanBannedTypes, Type: ConfigString},
+			configValue{Key: ConfigJikanMaxEpisodes, Default: DefaultJikanMaxEpisodes, Type: ConfigInt},
+			configValue{Key: ConfigTmdbEnabled, Default: DefaultTmdbEnabled, Type: ConfigBool},
 			configValue{Key: ConfigTmdbToken, Default: DefaultTmdbToken, Type: ConfigString},
 
 			configValue{Key: ConfigMaxNameLength, Default: DefaultMaxNameLength, Type: ConfigInt},

--- a/admin.go
+++ b/admin.go
@@ -344,6 +344,9 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 		MaxUserVotes           int
 		EntriesRequireApproval bool
 		VotingEnabled          bool
+		AutofillEnabled        bool
+		JikanEnabled           bool
+		TmdbEnabled            bool
 		TmdbToken              string
 		MaxNameLength          int
 		MinNameLength          int
@@ -407,6 +410,26 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 			s.data.SetCfgBool(ConfigVotingEnabled, true)
 		}
 
+		jikanEnabled := r.PostFormValue("JikanEnabled")
+		if jikanEnabled == "" {
+			s.data.SetCfgBool(ConfigJikanEnabled, false)
+		} else {
+			s.data.SetCfgBool(ConfigJikanEnabled, true)
+		}
+
+		tmdbEnabled := r.PostFormValue("TmdbEnabled")
+		if tmdbEnabled == "" {
+			s.data.SetCfgBool(ConfigTmdbEnabled, false)
+		} else {
+			s.data.SetCfgBool(ConfigTmdbEnabled, true)
+		}
+
+		autofillEnabled := r.PostFormValue("AutofillEnabled")
+		if autofillEnabled == "" {
+			s.data.SetCfgBool(ConfigAutofillEnabled, false)
+		} else {
+			s.data.SetCfgBool(ConfigAutofillEnabled, true)
+		}
 		tmdbToken := r.PostFormValue("TmdbToken")
 		s.data.SetCfgString(ConfigTmdbToken, tmdbToken)
 
@@ -490,6 +513,39 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 		err = s.data.SetCfgBool(ConfigVotingEnabled, data.VotingEnabled)
 		if err != nil {
 			s.l.Error("Error saving new configuration value for VotingEnabled: %s", err)
+		}
+	}
+
+	data.AutofillEnabled, err = s.data.GetCfgBool(ConfigAutofillEnabled, DefaultAutofillEnabled)
+	if err != nil {
+		s.l.Error("Error getting configuration value for %s: %s", ConfigAutofillEnabled, err)
+
+		// try to resave new value
+		err = s.data.SetCfgBool(ConfigAutofillEnabled, data.AutofillEnabled)
+		if err != nil {
+			s.l.Error("Error saving new configuration value for %s: %s", ConfigAutofillEnabled, err)
+		}
+	}
+
+	data.JikanEnabled, err = s.data.GetCfgBool(ConfigJikanEnabled, DefaultJikanEnabled)
+	if err != nil {
+		s.l.Error("Error getting configuration value for %s: %s", ConfigJikanEnabled, err)
+
+		// try to resave new value
+		err = s.data.SetCfgBool(ConfigJikanEnabled, data.JikanEnabled)
+		if err != nil {
+			s.l.Error("Error saving new configuration value for %s: %s", ConfigJikanEnabled, err)
+		}
+	}
+
+	data.TmdbEnabled, err = s.data.GetCfgBool(ConfigTmdbEnabled, DefaultTmdbEnabled)
+	if err != nil {
+		s.l.Error("Error getting configuration value for %s: %s", ConfigTmdbToken, err)
+
+		// try to resave new value
+		err = s.data.SetCfgBool(ConfigTmdbEnabled, data.TmdbEnabled)
+		if err != nil {
+			s.l.Error("Error saving new configuration value for %s: %s", ConfigTmdbToken, err)
 		}
 	}
 

--- a/admin.go
+++ b/admin.go
@@ -346,6 +346,7 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 		VotingEnabled          bool
 		AutofillEnabled        bool
 		JikanEnabled           bool
+		JikanBannedTypes       string
 		TmdbEnabled            bool
 		TmdbToken              string
 		MaxNameLength          int
@@ -430,8 +431,12 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 		} else {
 			s.data.SetCfgBool(ConfigAutofillEnabled, true)
 		}
+
 		tmdbToken := r.PostFormValue("TmdbToken")
 		s.data.SetCfgString(ConfigTmdbToken, tmdbToken)
+
+		jikanBannedTypes := r.PostFormValue("JikanBannedTypes")
+		s.data.SetCfgString(ConfigJikanBannedTypes, jikanBannedTypes)
 
 		maxNameLengthStr := r.PostFormValue("MaxNameLength")
 		maxNameLength, err := strconv.ParseInt(maxNameLengthStr, 10, 32)
@@ -557,6 +562,17 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 		err = s.data.SetCfgString(ConfigTmdbToken, data.TmdbToken)
 		if err != nil {
 			s.l.Error("Error saving new configuration value for TmdbToken: %s", err)
+		}
+	}
+
+	data.JikanBannedTypes, err = s.data.GetCfgString(ConfigJikanBannedTypes, DefaultJikanBannedTypes)
+	if err != nil {
+		s.l.Error("Error getting configuration value for %s: %s", ConfigJikanBannedTypes, err)
+
+		// try to resave new value
+		err = s.data.SetCfgString(ConfigJikanBannedTypes, data.JikanBannedTypes)
+		if err != nil {
+			s.l.Error("Error saving new configuration value for %s: %s", ConfigJikanBannedTypes, err)
 		}
 	}
 

--- a/dataimporter.go
+++ b/dataimporter.go
@@ -56,7 +56,11 @@ func (t tmdb) getTitle() (string, error) {
 	if err != nil || resp.StatusCode != 200 {
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\nMaybe check your tmdb api token")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return "", err
+		}
 
 		var dat map[string][]map[string]interface{}
 
@@ -88,8 +92,11 @@ func (t tmdb) getDesc() (string, error) {
 
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\nMaybe check your tmdb api token")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
 
+		if err != nil {
+			return "", err
+		}
 		var dat map[string][]map[string]interface{}
 
 		if err := json.Unmarshal(body, &dat); err != nil {
@@ -115,7 +122,10 @@ func (t tmdb) getPoster() (string, error) {
 
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\nMaybe check your tmdb api token")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
 
 		var dat map[string][]map[string]interface{}
 
@@ -152,7 +162,10 @@ func (j jikan) getTitle() (string, error) {
 	if err != nil || resp.StatusCode != 200 {
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\n Request URL: " + "https://api.jikan.moe/v3/anime/" + j.id + "\n")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
 
 		var dat map[string]interface{}
 
@@ -179,7 +192,10 @@ func (j jikan) getDesc() (string, error) {
 
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\n Request URL: " + "https://api.jikan.moe/v3/anime/" + j.id + "\n")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
 
 		var dat map[string]interface{}
 
@@ -203,7 +219,10 @@ func (j jikan) getPoster() (string, error) {
 	if err != nil || resp.StatusCode != 200 {
 		return "", errors.New("\n\nTried to access API - Response Code: " + resp.Status + "\n Request URL: " + "https://api.jikan.moe/v3/anime/" + j.id + "\n")
 	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
 
 		var dat map[string]interface{}
 

--- a/dataimporter.go
+++ b/dataimporter.go
@@ -191,10 +191,13 @@ func (j *jikan) requestResults() error {
 func (j *jikan) getTitle() (string, error) {
 
 	title := ""
-
 	dat := j.resp
 
-	title = (*dat)["title"].(string)
+	if (*dat)["title"] != nil {
+		title = (*dat)["title"].(string)
+	} else {
+		return "", errors.New("No title returned from API")
+	}
 
 	if (*dat)["title_english"] != nil && (*dat)["title_english"].(string) != (*dat)["title"].(string) {
 		title += " (" + (*dat)["title_english"].(string) + ")"
@@ -204,27 +207,28 @@ func (j *jikan) getTitle() (string, error) {
 }
 
 func (j *jikan) getDesc() (string, error) {
-
-	desc := ""
-
 	dat := j.resp
 
-	desc = (*dat)["synopsis"].(string)
+	if (*dat)["synopsis"] != nil {
+		return (*dat)["synopsis"].(string), nil
+	}
 
-	return desc, nil
+	return "", nil
 
 }
 
 func (j *jikan) getPoster() (string, error) {
 
 	fileurl := ""
-
 	dat := j.resp
 
-	fileurl = (*dat)["image_url"].(string)
+	if (*dat)["image_url"] != nil {
+		fileurl = (*dat)["image_url"].(string)
+	} else {
+		return "", nil
+	}
 
 	path := "posters/" + j.id + ".jpg"
-
 	err := DownloadFile(path, fileurl)
 
 	if !(err == nil) {

--- a/dataimporter.go
+++ b/dataimporter.go
@@ -3,10 +3,12 @@ package moviepoll
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/zorchenhimer/MoviePolls/common"
 )
@@ -26,10 +28,10 @@ type tmdb struct {
 }
 
 type jikan struct {
-	l            *common.Logger
-	id           string
-	excludeTypes []string
-	resp         *map[string]interface{}
+	l             *common.Logger
+	id            string
+	excludedTypes []string
+	resp          *map[string]interface{}
 }
 
 func getMovieData(api dataapi) ([]string, error) {
@@ -161,6 +163,13 @@ func (j *jikan) requestResults() error {
 
 		if err := json.Unmarshal(body, &dat); err != nil {
 			return errors.New("Error while unmarshalling json response")
+		}
+
+		for _, etype := range j.excludedTypes {
+			thisType := dat["type"].(string)
+			if strings.ToLower(thisType) == strings.ToLower(etype) {
+				return fmt.Errorf("The anime type %s was banned by the sites administrator. Please choose a different type!", thisType)
+			}
 		}
 
 		j.resp = &dat

--- a/dataimporter.go
+++ b/dataimporter.go
@@ -32,6 +32,7 @@ type jikan struct {
 	id            string
 	excludedTypes []string
 	resp          *map[string]interface{}
+	maxEpisodes   int
 }
 
 func getMovieData(api dataapi) ([]string, error) {
@@ -170,6 +171,12 @@ func (j *jikan) requestResults() error {
 			if strings.ToLower(thisType) == strings.ToLower(etype) {
 				return fmt.Errorf("The anime type %s was banned by the sites administrator. Please choose a different type!", thisType)
 			}
+		}
+
+		episodes := dat["episodes"].(float64)
+
+		if int(episodes) > int(j.maxEpisodes) && int(j.maxEpisodes) != 0 {
+			return fmt.Errorf("The anime has too many (%d) episodes. The site administrator only allowed animes up to %d episodes.", int(episodes), int(j.maxEpisodes))
 		}
 
 		j.resp = &dat

--- a/dataimporter.go
+++ b/dataimporter.go
@@ -173,10 +173,14 @@ func (j *jikan) requestResults() error {
 			}
 		}
 
-		episodes := dat["episodes"].(float64)
+		if dat["episodes"] != nil {
+			episodes := dat["episodes"].(float64)
 
-		if int(episodes) > int(j.maxEpisodes) && int(j.maxEpisodes) != 0 {
-			return fmt.Errorf("The anime has too many (%d) episodes. The site administrator only allowed animes up to %d episodes.", int(episodes), int(j.maxEpisodes))
+			if int(episodes) > int(j.maxEpisodes) && int(j.maxEpisodes) != 0 {
+				return fmt.Errorf("The anime has too many (%d) episodes. The site administrator only allowed animes up to %d episodes.", int(episodes), int(j.maxEpisodes))
+			}
+		} else {
+			return fmt.Errorf("The episode count of this anime has not been published yet. Therefore this anime can not be added.")
 		}
 
 		j.resp = &dat

--- a/server.go
+++ b/server.go
@@ -25,6 +25,7 @@ const (
 	DefaultVotingEnabled          bool   = false
 	DefaultJikanEnabled           bool   = false
 	DefaultJikanBannedTypes       string = "TV,music"
+	DefaultJikanMaxEpisodes       int    = 1
 	DefaultTmdbEnabled            bool   = false
 	DefaultTmdbToken              string = ""
 	DefaultMaxNameLength          int    = 100
@@ -44,6 +45,7 @@ const (
 	ConfigTmdbToken              string = "TmdbToken"
 	ConfigJikanEnabled           string = "JikanEnabled"
 	ConfigJikanBannedTypes       string = "JikanBannedTypes"
+	ConfigJikanMaxEpisodes       string = "JikanMaxEpisodes"
 	ConfigTmdbEnabled            string = "TmdbEnabled"
 	ConfigMaxNameLength          string = "MaxNameLength"
 	ConfigMinNameLength          string = "MinNameLength"

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ const (
 	DefaultAutofillEnabled        bool   = false
 	DefaultVotingEnabled          bool   = false
 	DefaultJikanEnabled           bool   = false
+	DefaultJikanBannedTypes       string = "TV,music"
 	DefaultTmdbEnabled            bool   = false
 	DefaultTmdbToken              string = ""
 	DefaultMaxNameLength          int    = 100
@@ -42,6 +43,7 @@ const (
 	ConfigAutofillEnabled        string = "AutofillEnabled"
 	ConfigTmdbToken              string = "TmdbToken"
 	ConfigJikanEnabled           string = "JikanEnabled"
+	ConfigJikanBannedTypes       string = "JikanBannedTypes"
 	ConfigTmdbEnabled            string = "TmdbEnabled"
 	ConfigMaxNameLength          string = "MaxNameLength"
 	ConfigMinNameLength          string = "MinNameLength"

--- a/server.go
+++ b/server.go
@@ -21,7 +21,10 @@ const SessionName string = "moviepoll-session"
 const (
 	DefaultMaxUserVotes           int    = 5
 	DefaultEntriesRequireApproval bool   = false
+	DefaultAutofillEnabled        bool   = false
 	DefaultVotingEnabled          bool   = false
+	DefaultJikanEnabled           bool   = false
+	DefaultTmdbEnabled            bool   = false
 	DefaultTmdbToken              string = ""
 	DefaultMaxNameLength          int    = 100
 	DefaultMinNameLength          int    = 4
@@ -36,7 +39,10 @@ const (
 	ConfigVotingEnabled          string = "VotingEnabled"
 	ConfigMaxUserVotes           string = "MaxUserVotes"
 	ConfigEntriesRequireApproval string = "EntriesRequireApproval"
+	ConfigAutofillEnabled        string = "AutofillEnabled"
 	ConfigTmdbToken              string = "TmdbToken"
+	ConfigJikanEnabled           string = "JikanEnabled"
+	ConfigTmdbEnabled            string = "TmdbEnabled"
 	ConfigMaxNameLength          string = "MaxNameLength"
 	ConfigMinNameLength          string = "MinNameLength"
 	ConfigNoticeBanner           string = "NoticeBanner"
@@ -290,8 +296,20 @@ func (s *Server) handlerAddMovie(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	autofillEnabled, err := s.data.GetCfgBool(ConfigAutofillEnabled, DefaultAutofillEnabled)
+
+	if err != nil {
+		s.doError(
+			http.StatusInternalServerError,
+			"Something went wrong :C",
+			w, r)
+
+		s.l.Error("Unable to get config value %s: %v", ConfigAutofillEnabled, err)
+		return
+	}
 	data := dataAddMovie{
-		dataPageBase: s.newPageBase("Add Movie", w, r),
+		dataPageBase:    s.newPageBase("Add Movie", w, r),
+		AutofillEnabled: autofillEnabled,
 	}
 
 	if r.Method == "POST" {
@@ -618,107 +636,157 @@ func (s *Server) handleAutofill(links []string, w http.ResponseWriter, r *http.R
 	// make sure we have a link to look at
 	if len(links) >= 1 {
 		sourcelink := links[0]
-
-		if strings.Contains(sourcelink, "myanimelist") {
-			// Get Data from MAL (jikan api)
-			rgx := regexp.MustCompile(`[htp]{4}s?:\/\/[^\/]*\/anime\/([0-9]*)`)
-			match := rgx.FindStringSubmatch(sourcelink)
-			id := match[1]
-
-			sourceAPI := jikan{id: id}
-
-			// Return early when the title already exists
-			title, err := sourceAPI.getTitle()
-			if err == nil {
-				exists, err := s.data.CheckMovieExists(title)
-				if err == nil {
-					if exists {
-						errors = append(errors, "Movie already exists")
-						rerenderSite = true
-						return nil, errors, rerenderSite
-					}
-				} else {
-					s.l.Error("CheckMovieExsists(): " + err.Error())
-				}
-			} else {
-				s.l.Error("getTitle(): " + err.Error())
-			}
-
-			results, err = getMovieData(sourceAPI)
-
-			if err != nil {
-				// error while getting data from the api
-				errors = append(errors, err.Error())
-			}
-
-		} else if strings.Contains(sourcelink, "imdb") {
-			// Retrieve token from database
-			token, err := s.data.GetCfgString("TmdbToken", "")
-			if err != nil || token == "" {
-				errors = append(errors, "TmdbToken is either empty or not set in the admin config")
-				rerenderSite = true
-				return nil, errors, rerenderSite
-			}
-
-			// get the movie id
-			rgx := regexp.MustCompile(`[htp]{4}s?:\/\/[^\/]*\/title\/(tt[0-9]*)`)
-			match := rgx.FindStringSubmatch(sourcelink)
-			id := match[1]
-
-			sourceAPI := tmdb{id: id, token: token}
-
-			// Return early when the title already exists
-			title, err := sourceAPI.getTitle()
-			if err == nil {
-				exists, _ := s.data.CheckMovieExists(title)
-				if err == nil {
-					if exists {
-						errors = append(errors, "Movie already exists")
-						rerenderSite = true
-						return nil, errors, rerenderSite
-					}
-				}
-
-				results, err = getMovieData(sourceAPI)
-
-				if err != nil {
-					// errors from getMovieData
-					errors = append(errors, err.Error())
-				}
-
-			} else {
-				// Errors from sourceAPI.getTitle
-				errors = append(errors, err.Error())
-			}
-		} else {
-			// neither IMDB nor MAL link
-			errors = append(errors, "To use autofill use an imdb or myanimelist link as first link")
+		autofillEnabled, err := s.data.GetCfgBool(ConfigAutofillEnabled, DefaultJikanEnabled)
+		if err != nil {
+			s.l.Error("Error while retriving config value %s:\n %v", ConfigAutofillEnabled, err)
+			errors = append(errors, "Something went wrong :C")
+			rerenderSite = true
+			return nil, errors, rerenderSite
 		}
 
-		if len(results) > 0 {
-			if results[0] == "" && results[1] == "" && results[2] == "" {
-				errors = append(errors, "The provided imdb link is not a link to a movie!")
+		if autofillEnabled {
+
+			if strings.Contains(sourcelink, "myanimelist") {
+
+				jikanEnabled, err := s.data.GetCfgBool("JikanEnabled", DefaultJikanEnabled)
+				if err != nil {
+					s.l.Error("Error while retriving config value 'JikanEnabled':\n %v", err)
+					errors = append(errors, "Something went wrong :C")
+					rerenderSite = true
+					return nil, errors, rerenderSite
+				}
+
+				s.l.Debug("jikanEnabled: %v", jikanEnabled)
+
+				if jikanEnabled {
+					// Get Data from MAL (jikan api)
+					rgx := regexp.MustCompile(`[htp]{4}s?:\/\/[^\/]*\/anime\/([0-9]*)`)
+					match := rgx.FindStringSubmatch(sourcelink)
+					id := match[1]
+
+					sourceAPI := jikan{id: id}
+
+					// Return early when the title already exists
+					title, err := sourceAPI.getTitle()
+					if err == nil {
+						exists, err := s.data.CheckMovieExists(title)
+						if err == nil {
+							if exists {
+								errors = append(errors, "Movie already exists")
+								rerenderSite = true
+								return nil, errors, rerenderSite
+							}
+						} else {
+							s.l.Error("CheckMovieExsists(): " + err.Error())
+						}
+					} else {
+						s.l.Error("getTitle(): " + err.Error())
+					}
+
+					results, err = getMovieData(sourceAPI)
+
+					if err != nil {
+						// error while getting data from the api
+						errors = append(errors, err.Error())
+					}
+				} else {
+					errors = append(errors, "Jikan API usage was not enabled by the site administrator")
+					rerenderSite = true
+					return nil, errors, rerenderSite
+
+				}
+
+			} else if strings.Contains(sourcelink, "imdb") {
+
+				tmdbEnabled, err := s.data.GetCfgBool("TmdbEnabled", DefaultTmdbEnabled)
+				if err != nil {
+					s.l.Error("Error while retriving config value 'TmdbEnabled':\n %v", err)
+					errors = append(errors, "Something went wrong :C")
+					rerenderSite = true
+					return nil, errors, rerenderSite
+				}
+
+				if tmdbEnabled {
+					// Retrieve token from database
+					token, err := s.data.GetCfgString("TmdbToken", "")
+					if err != nil || token == "" {
+						errors = append(errors, "TmdbToken is either empty or not set in the admin config")
+						rerenderSite = true
+						return nil, errors, rerenderSite
+					}
+
+					// get the movie id
+					rgx := regexp.MustCompile(`[htp]{4}s?:\/\/[^\/]*\/title\/(tt[0-9]*)`)
+					match := rgx.FindStringSubmatch(sourcelink)
+					id := match[1]
+
+					sourceAPI := tmdb{id: id, token: token}
+
+					// Return early when the title already exists
+					title, err := sourceAPI.getTitle()
+					if err == nil {
+						exists, _ := s.data.CheckMovieExists(title)
+						if err == nil {
+							if exists {
+								errors = append(errors, "Movie already exists")
+								rerenderSite = true
+								return nil, errors, rerenderSite
+							}
+						}
+
+						results, err = getMovieData(sourceAPI)
+
+						if err != nil {
+							// errors from getMovieData
+							errors = append(errors, err.Error())
+						}
+
+					} else {
+						// Errors from sourceAPI.getTitle
+						errors = append(errors, err.Error())
+					}
+				} else {
+					errors = append(errors, "Tmdb API usage was not enabled by the site administrator")
+					rerenderSite = true
+					return nil, errors, rerenderSite
+
+				}
+
+			} else {
+				// neither IMDB nor MAL link
+				errors = append(errors, "To use autofill use an imdb or myanimelist link as first link")
 			}
 
-			//duplicate check
-			movieExists, err := s.data.CheckMovieExists(results[0])
-			if err != nil {
-				s.doError(
-					http.StatusInternalServerError,
-					fmt.Sprintf("Unable to check if movie exists: %v", err),
-					w, r)
-				return nil, errors, rerenderSite
-			}
+			if len(results) > 0 {
+				if results[0] == "" && results[1] == "" && results[2] == "" {
+					errors = append(errors, "The provided imdb link is not a link to a movie!")
+				}
 
-			if movieExists {
-				errors = append(errors, "Movie already exists")
+				//duplicate check
+				movieExists, err := s.data.CheckMovieExists(results[0])
+				if err != nil {
+					s.doError(
+						http.StatusInternalServerError,
+						fmt.Sprintf("Unable to check if movie exists: %v", err),
+						w, r)
+					return nil, errors, rerenderSite
+				}
+
+				if movieExists {
+					errors = append(errors, "Movie already exists")
+				}
+			} else {
+				errors = append(errors, "No results retrived from API")
 			}
 		} else {
-			errors = append(errors, "No results retrived from API")
+			errors = append(errors, "Autofill from link was not enabled by the site administrator")
+			rerenderSite = true
+			return nil, errors, rerenderSite
 		}
 	} else {
 		errors = append(errors, "No links provided")
 	}
+
 	return results, errors, rerenderSite
 }
 

--- a/server.go
+++ b/server.go
@@ -666,10 +666,21 @@ func (s *Server) handleAutofill(links []string, w http.ResponseWriter, r *http.R
 					match := rgx.FindStringSubmatch(sourcelink)
 					id := match[1]
 
-					sourceAPI := jikan{id: id, l: s.l}
+					bannedTypesString, err := s.data.GetCfgString(ConfigJikanBannedTypes, DefaultJikanBannedTypes)
+
+					if err != nil {
+						s.l.Error("Error while retriving config value 'JikanBannedTypes':\n %v", err)
+						errors = append(errors, "Something went wrong :C")
+						rerenderSite = true
+						return nil, errors, rerenderSite
+					}
+
+					bannedTypes := strings.Split(bannedTypesString, ",")
+
+					sourceAPI := jikan{id: id, l: s.l, excludedTypes: bannedTypes}
 
 					// Return early when the title already exists
-					err := sourceAPI.requestResults()
+					err = sourceAPI.requestResults()
 					if err != nil {
 						errors = append(errors, err.Error())
 						rerenderSite = true

--- a/server.go
+++ b/server.go
@@ -640,7 +640,7 @@ func (s *Server) handleAutofill(links []string, w http.ResponseWriter, r *http.R
 	// make sure we have a link to look at
 	if len(links) >= 1 {
 		sourcelink := links[0]
-		autofillEnabled, err := s.data.GetCfgBool(ConfigAutofillEnabled, DefaultJikanEnabled)
+		autofillEnabled, err := s.data.GetCfgBool(ConfigAutofillEnabled, DefaultAutofillEnabled)
 		if err != nil {
 			s.l.Error("Error while retriving config value %s:\n %v", ConfigAutofillEnabled, err)
 			errors = append(errors, "Something went wrong :C")
@@ -679,7 +679,16 @@ func (s *Server) handleAutofill(links []string, w http.ResponseWriter, r *http.R
 
 					bannedTypes := strings.Split(bannedTypesString, ",")
 
-					sourceAPI := jikan{id: id, l: s.l, excludedTypes: bannedTypes}
+					maxEpisodes, err := s.data.GetCfgInt(ConfigJikanMaxEpisodes, DefaultJikanMaxEpisodes)
+
+					if err != nil {
+						s.l.Error("Error while retriving config value 'JikanMaxEpisodes':\n %v", err)
+						errors = append(errors, "Something went wrong :C")
+						rerenderSite = true
+						return nil, errors, rerenderSite
+					}
+
+					sourceAPI := jikan{id: id, l: s.l, excludedTypes: bannedTypes, maxEpisodes: maxEpisodes}
 
 					// Return early when the title already exists
 					err = sourceAPI.requestResults()

--- a/templates.go
+++ b/templates.go
@@ -140,6 +140,8 @@ type dataAddMovie struct {
 	ValDescription string
 	ValLinks       string
 	//ValPoster      bool
+
+	AutofillEnabled bool
 }
 
 func (d dataAddMovie) isError() bool {

--- a/templates/add-movie.html
+++ b/templates/add-movie.html
@@ -19,10 +19,12 @@
             <div{{if .ErrPoster}} class="errorMessage"{{end}}><label for="PosterFile">Poster Image<label></div>
             <div><input type="file" name="PosterFile" id="PosterFile" accept="image/*"/></div>
         </div>
+		{{if .AutofillEnabled}}
 		<div class="movieInput">
 			<div{{if .ErrAutofill}} class="errorMessage"{{end}}><label for="AutofillBox">Autofill Data with the provided Link<label></div>
 			<div><input type="checkbox" name="AutofillBox" id="AutofillBox" /></div>
 		</div>
+		{{end}}
         <div class="movieInput">
             <div><input type="submit" value="Add Movie" /></div>
         </div>

--- a/templates/add-movie.html
+++ b/templates/add-movie.html
@@ -5,23 +5,23 @@
     {{if .ErrorMessage}}<div class="errorMessage"><ul>{{range .ErrorMessage}}<li>{{.}}</li>{{end}}</ul></div>{{end}}
     <div id="addMovieForm">
         <div class="movieInput">
-            <div{{if .ErrTitle}} class="errorMessage"{{end}}><label for="MovieName">Movie Title<label></div>
+            <div{{if .ErrTitle}} class="errorMessage"{{end}}><label for="MovieName">Movie Title</label></div>
             <div><input type="text" name="MovieName" id="MovieName"{{if .ValTitle}} value="{{.ValTitle}}"{{end}} /></div>
         </div>
         <div class="movieInput">
-            <div{{if .ErrDescription}} class="errorMessage"{{end}}><label for="Description">Description<label></div>
+            <div{{if .ErrDescription}} class="errorMessage"{{end}}><label for="Description">Description</label></div>
             <div><textarea name="Description" id="Description">{{if .ValDescription}}{{.ValDescription}}{{end}}</textarea></div>
         <div class="movieInput">
-            <div{{if .ErrLinks}} class="errorMessage"{{end}}><label for="Links">Links<label></div>
+            <div{{if .ErrLinks}} class="errorMessage"{{end}}><label for="Links">Links</label></div>
             <div><textarea name="Links" id="Links">{{if .ValLinks}}{{.ValLinks}}{{end}}</textarea></div>
         </div>
         <div class="movieInput">
-            <div{{if .ErrPoster}} class="errorMessage"{{end}}><label for="PosterFile">Poster Image<label></div>
+            <div{{if .ErrPoster}} class="errorMessage"{{end}}><label for="PosterFile">Poster Image</label></div>
             <div><input type="file" name="PosterFile" id="PosterFile" accept="image/*"/></div>
         </div>
 		{{if .AutofillEnabled}}
 		<div class="movieInput">
-			<div{{if .ErrAutofill}} class="errorMessage"{{end}}><label for="AutofillBox">Autofill Data with the provided Link<label></div>
+			<div{{if .ErrAutofill}} class="errorMessage"{{end}}><label for="AutofillBox">Autofill Data with the provided Link</label></div>
 			<div><input type="checkbox" name="AutofillBox" id="AutofillBox" /></div>
 		</div>
 		{{end}}

--- a/templates/admin/config.html
+++ b/templates/admin/config.html
@@ -48,9 +48,13 @@
     </div>
 
 	{{if .AutofillEnabled}}
-	 <div class="configItem">
+	<div class="configItem">
         <label for="JikanEnabled">Enable Jikan API usage</label>
         <input type="checkbox" id="JikanEnabled" name="JikanEnabled" {{if .JikanEnabled}}checked {{end}}/>
+    </div>
+	<div class="configItem">
+		<label for="JikanBannedTypes">Types of anime to be restricted from being added. (For reference see <a href="https://jikan.docs.apiary.io/#reference/0/search">Jikan API Documentation</a>. Input is expected as a comma seperated list, i.e. TV,OVA,ONA</label>
+		<input type="text" id="JikanBannedTypes" name="JikanBannedTypes" value="{{.JikanBannedTypes}}"/>
     </div>
 
 	 <div class="configItem">

--- a/templates/admin/config.html
+++ b/templates/admin/config.html
@@ -57,6 +57,12 @@
 		<input type="text" id="JikanBannedTypes" name="JikanBannedTypes" value="{{.JikanBannedTypes}}"/>
     </div>
 
+	<div class="configItem rowAlt">
+        <label for="JikanMaxEpisodes">Max Number of episodes for anime to be added (0 for unlimited)</label>
+        <input type="number" id="JikanMaxEpisodes" name="JikanMaxEpisodes" value="{{.JikanMaxEpisodes}}"/>
+    </div>
+
+
 	 <div class="configItem">
         <label for="TmdbEnabled">Enable Tmdb API usage (requires a valid API Key)</label>
         <input type="checkbox" id="TmdbEnabled" name="TmdbEnabled" {{if .TmdbEnabled}}checked {{end}}/>

--- a/templates/admin/config.html
+++ b/templates/admin/config.html
@@ -25,11 +25,6 @@
         <input type="checkbox" id="VotingEnabled" name="VotingEnabled" {{if .VotingEnabled}}checked {{end}}/>
     </div>
 
-    <div class="configItem rowAlt">
-        <label for="TmdbToken">Your tMDB Token</label>
-        <input type="password" id="TmdbToken" name="TmdbToken" value="{{.TmdbToken}}"/>
-    </div>
-
     <div class="configItem">
         <label for="MinNameLength">Min Username Length</label>
         <input type="number" id="MinNameLength" name="MinNameLength" value="{{.MinNameLength}}"/>
@@ -44,6 +39,32 @@
         <label for="NoticeMessage">Notice banner message (blank hides)</label>
         <input type="text" id="NoticeMessage" name="NoticeMessage" value="{{.NoticeMessage}}"/>
     </div>
+    <div class="configItem">
+        <hr style="width:100%" />
+    </div>
+	<div class="configItem">
+        <label for="AutofillEnabled">Enable Autofill from APIs</label>
+        <input type="checkbox" id="AutofillEnabled" name="AutofillEnabled" {{if .AutofillEnabled}}checked {{end}}/>
+    </div>
+
+	{{if .AutofillEnabled}}
+	 <div class="configItem">
+        <label for="JikanEnabled">Enable Jikan API usage</label>
+        <input type="checkbox" id="JikanEnabled" name="JikanEnabled" {{if .JikanEnabled}}checked {{end}}/>
+    </div>
+
+	 <div class="configItem">
+        <label for="TmdbEnabled">Enable Tmdb API usage (requires a valid API Key)</label>
+        <input type="checkbox" id="TmdbEnabled" name="TmdbEnabled" {{if .TmdbEnabled}}checked {{end}}/>
+    </div>
+
+	<div class="configItem rowAlt">
+        <label for="TmdbToken">Your tMDB API Key</label>
+        <input type="password" id="TmdbToken" name="TmdbToken" value="{{.TmdbToken}}"/>
+    </div>
+	{{end}}
+
+
 
     <div class="configItem">
         <hr style="width:100%" />

--- a/templates/admin/config.html
+++ b/templates/admin/config.html
@@ -25,6 +25,11 @@
         <input type="checkbox" id="VotingEnabled" name="VotingEnabled" {{if .VotingEnabled}}checked {{end}}/>
     </div>
 
+    <div class="configItem rowAlt">
+        <label for="TmdbToken">Your tMDB Token</label>
+        <input type="password" id="TmdbToken" name="TmdbToken" value="{{.TmdbToken}}"/>
+    </div>
+
     <div class="configItem">
         <label for="MinNameLength">Min Username Length</label>
         <input type="number" id="MinNameLength" name="MinNameLength" value="{{.MinNameLength}}"/>
@@ -39,42 +44,6 @@
         <label for="NoticeMessage">Notice banner message (blank hides)</label>
         <input type="text" id="NoticeMessage" name="NoticeMessage" value="{{.NoticeMessage}}"/>
     </div>
-    <div class="configItem">
-        <hr style="width:100%" />
-    </div>
-	<div class="configItem">
-        <label for="AutofillEnabled">Enable Autofill from APIs</label>
-        <input type="checkbox" id="AutofillEnabled" name="AutofillEnabled" {{if .AutofillEnabled}}checked {{end}}/>
-    </div>
-
-	{{if .AutofillEnabled}}
-	<div class="configItem">
-        <label for="JikanEnabled">Enable Jikan API usage</label>
-        <input type="checkbox" id="JikanEnabled" name="JikanEnabled" {{if .JikanEnabled}}checked {{end}}/>
-    </div>
-	<div class="configItem">
-		<label for="JikanBannedTypes">Types of anime to be restricted from being added. (For reference see <a href="https://jikan.docs.apiary.io/#reference/0/search">Jikan API Documentation</a>. Input is expected as a comma seperated list, i.e. TV,OVA,ONA</label>
-		<input type="text" id="JikanBannedTypes" name="JikanBannedTypes" value="{{.JikanBannedTypes}}"/>
-    </div>
-
-	<div class="configItem rowAlt">
-        <label for="JikanMaxEpisodes">Max Number of episodes for anime to be added (0 for unlimited)</label>
-        <input type="number" id="JikanMaxEpisodes" name="JikanMaxEpisodes" value="{{.JikanMaxEpisodes}}"/>
-    </div>
-
-
-	 <div class="configItem">
-        <label for="TmdbEnabled">Enable Tmdb API usage (requires a valid API Key)</label>
-        <input type="checkbox" id="TmdbEnabled" name="TmdbEnabled" {{if .TmdbEnabled}}checked {{end}}/>
-    </div>
-
-	<div class="configItem rowAlt">
-        <label for="TmdbToken">Your tMDB API Key</label>
-        <input type="password" id="TmdbToken" name="TmdbToken" value="{{.TmdbToken}}"/>
-    </div>
-	{{end}}
-
-
 
     <div class="configItem rowAlt">
         <label for="MaxTitleLength">Max Title Length</label>


### PR DESCRIPTION
This pullrequest adds the ability to restrict the addition of a movie by MAL's anime type classification as well as the amount of episodes of this anime.
The accompanying configuration is found in the admin panel.
Regarding the admin panel i added an option to en/disable the autofillBox as a whole as well as the specific api endpoints in particular (i.e. disable jikan while still using Tmdb).
When the AutofillBox is disabled all other configuration options regarding autofilling are hidden in the admin panel.