### PR TITLE
Added Remarks to the movie struct

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -385,6 +385,7 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 			configValue{Key: ConfigMaxTitleLength, Default: DefaultMaxTitleLength, Type: ConfigInt},
 			configValue{Key: ConfigMaxDescriptionLength, Default: DefaultMaxDescriptionLength, Type: ConfigInt},
 			configValue{Key: ConfigMaxLinkLength, Default: DefaultMaxLinkLength, Type: ConfigInt},
+			configValue{Key: ConfigMaxRemarksLength, Default: DefaultMaxRemarksLength, Type: ConfigInt},
 		},
 
 		TypeString: ConfigString,

--- a/common/movie.go
+++ b/common/movie.go
@@ -11,6 +11,7 @@ type Movie struct {
 	Name        string
 	Links       []string
 	Description string
+	Remarks     string
 
 	CycleAdded   *Cycle
 	CycleWatched *Cycle
@@ -39,11 +40,12 @@ func (m Movie) String() string {
 		votes = append(votes, v.User.Name)
 	}
 
-	return fmt.Sprintf("Movie{Id:%d Name:%q Links:%s Description:%q CycleAdded:%s CycleWatched:%s Votes:%s}",
+	return fmt.Sprintf("Movie{Id:%d Name:%q Links:%s Description:%q Remarks:%s CycleAdded:%s CycleWatched:%s Votes:%s}",
 		m.Id,
 		m.Name,
 		m.Links,
 		m.Description,
+		m.Remarks,
 		m.CycleAdded,
 		m.CycleWatched,
 		votes,

--- a/data/json.go
+++ b/data/json.go
@@ -18,6 +18,7 @@ type jsonMovie struct {
 	Name           string
 	Links          []string
 	Description    string
+	Remarks        string
 	CycleAddedId   int
 	CycleWatchedId int
 	Removed        bool
@@ -45,6 +46,7 @@ func (j *jsonConnector) newJsonMovie(movie *common.Movie) jsonMovie {
 		Name:           movie.Name,
 		Links:          movie.Links,
 		Description:    movie.Description,
+		Remarks:        movie.Remarks,
 		CycleAddedId:   cycleId,
 		CycleWatchedId: cycleWatched,
 		Removed:        movie.Removed,
@@ -437,6 +439,7 @@ func (j *jsonConnector) movieFromJson(jMovie jsonMovie) *common.Movie {
 		Id:          jMovie.Id,
 		Name:        jMovie.Name,
 		Description: jMovie.Description,
+		Remarks:     jMovie.Remarks,
 		Removed:     jMovie.Removed,
 		Approved:    jMovie.Approved,
 		//CycleAdded:   j.findCycle(jMovie.CycleAddedId),

--- a/server.go
+++ b/server.go
@@ -368,7 +368,7 @@ func (s *Server) handlerAddMovie(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(remarks) > maxRemarksLength {
-			s.l.Debug("Links too long: %d", len(remarks))
+			s.l.Debug("Remarks too long: %d", len(remarks))
 			data.ErrRemarks = true
 			errText = append(errText, "Remarks too long!")
 		}

--- a/server.go
+++ b/server.go
@@ -34,6 +34,7 @@ const (
 	DefaultMaxTitleLength       int = 100
 	DefaultMaxDescriptionLength int = 1000
 	DefaultMaxLinkLength        int = 500 // length of all links combined
+	DefaultMaxRemarksLength     int = 200
 )
 
 // configuration keys
@@ -55,6 +56,7 @@ const (
 	ConfigMaxTitleLength       string = "MaxTitleLength"
 	ConfigMaxDescriptionLength string = "MaxDescriptionLength"
 	ConfigMaxLinkLength        string = "MaxLinkLength"
+	ConfigMaxRemarksLength     string = "MaxRemarksLength"
 )
 
 type Options struct {

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -165,6 +165,13 @@ a:hover {
     margin: 0.2em;
 }
 
+.adminMovie #name {
+	width: 60%;
+}
+
+.adminMovie #remarks {
+	width: 35%;
+}
 #endCycleForm {
     display:flex;
     flex-direction: row;

--- a/templates.go
+++ b/templates.go
@@ -132,6 +132,7 @@ type dataAddMovie struct {
 	ErrTitle       bool
 	ErrDescription bool
 	ErrLinks       bool
+	ErrRemarks     bool
 	ErrPoster      bool
 	ErrAutofill    bool
 
@@ -139,13 +140,14 @@ type dataAddMovie struct {
 	ValTitle       string
 	ValDescription string
 	ValLinks       string
+	ValRemarks     string
 	//ValPoster      bool
 
 	AutofillEnabled bool
 }
 
 func (d dataAddMovie) isError() bool {
-	return d.ErrTitle || d.ErrDescription || d.ErrLinks || d.ErrPoster || d.ErrAutofill
+	return d.ErrTitle || d.ErrDescription || d.ErrLinks || d.ErrPoster || d.ErrAutofill || d.ErrRemarks
 }
 
 type dataAccount struct {

--- a/templates/add-movie.html
+++ b/templates/add-movie.html
@@ -33,6 +33,10 @@
             <div{{if .ErrLinks}} class="errorMessage"{{end}}><label for="Links">Enter IMDB or MyAnimeList link for a movie to add:</label></div>
             <div><textarea name="Links" id="Links" style="width:400px">{{if .ValLinks}}{{.ValLinks}}{{end}}</textarea></div>
         </div>
+		<div class="movieInput">
+            <div{{if .ErrRemarks}} class="errorMessage"{{end}}><label for="Remarks">Enter your remarks here:</label></div>
+            <div><textarea name="Remarks" id="Remarks" style="width:400px">{{if .ValRemarks}}{{.ValRemarks}}{{end}}</textarea></div>
+        </div>
         <div class="movieInput">
             <div><input type="submit" value="Add Movie" /></div>
         </div>

--- a/templates/admin/endcycle.html
+++ b/templates/admin/endcycle.html
@@ -7,7 +7,8 @@
         <div class="adminMovie">
             <div><input type="checkbox" name="cb_{{.Id}}" checked="checked" /></div>
             <div>{{len .Votes}}</div>
-            <div>{{.Name}}</div>
+			<div id="name">{{.Name}}</div>
+			{{if .Remarks}}<div id="remarks">Remarks:</br>{{.Remarks}}</div>{{end}}
         </div>
     {{end}}
     <div>

--- a/templates/movie-info.html
+++ b/templates/movie-info.html
@@ -9,6 +9,10 @@
         <img src="/posters/{{.Movie.Poster}}" />
     </div>
     <div>
+		<p>Remarks by {{.Movie.AddedBy.Name}}:</p>
+		{{.Movie.Remarks}}
+
+		<p>Description:</p>
         {{.Movie.Description}}
     </div>
 </div>


### PR DESCRIPTION
Also added corresponding changes for the database connector (only json atm), as well as config fields on the admin panel.
The Remarks field is now displayed on movie-info.html and endcycle.html.
I also did some "fancy" :tm: css.

In my testing environment (some movies) the "migration" to the new movie struct worked for the json connector (field will get populated with null) so maybe it will work in production without needing to delete the db.

This fixes #55 