### PR TITLE
Added a Link struct to be used within the Movie struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SOURCES = \
 		  common/user.go \
 		  common/util.go \
 		  common/vote.go \
+		  common/link.go \
 		  data/connector.go \
 		  data/json.go \
 		  data/mysql.go \

--- a/admin.go
+++ b/admin.go
@@ -577,7 +577,12 @@ func (s *Server) handlerAdminMovieEdit(w http.ResponseWriter, r *http.Request) {
 				IsSource: source,
 			}
 
-			ls.Type, err = ls.DetermineLinkType()
+			err = ls.ValidateLink()
+			if err != nil {
+				s.l.Error("unable to validate link url: %v", err)
+			}
+
+			err = ls.DetermineLinkType()
 			if err != nil {
 				s.l.Error("unable to determine link type: %v", err)
 			}

--- a/cmd/migrateLinks.go
+++ b/cmd/migrateLinks.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/mapstructure"
+	mpc "github.com/zorchenhimer/MoviePolls/common"
+	mpd "github.com/zorchenhimer/MoviePolls/data"
+)
+
+const jsonFilename string = "db/data.json"
+
+func main() {
+	err := loadOldDB()
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+}
+
+type OldMovie struct {
+	Id             int
+	Name           string
+	Links          []string
+	Description    string
+	Remarks        string
+	Duration       string
+	Rating         float32
+	CycleAddedId   int
+	CycleWatchedId int
+	Removed        bool
+	Approved       bool
+	Poster         string
+	AddedBy        int
+	Tags           []int
+}
+
+func loadOldDB() error {
+
+	data, err := ioutil.ReadFile(jsonFilename)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var fullData map[string]interface{}
+
+	json.Unmarshal(data, &fullData)
+
+	// fullData now contains the whole db
+	jMovies := fullData["Movies"].(map[string]interface{})
+	oldmovies := []OldMovie{}
+	for _, movie := range jMovies {
+		om := &OldMovie{}
+		mapstructure.Decode(movie, &om)
+		oldmovies = append(oldmovies, *om)
+	}
+
+	delete(fullData, "Movies")
+
+	data, err = json.MarshalIndent(fullData, "", " ")
+
+	err = ioutil.WriteFile("db/temp.json", data, 666)
+	if err != nil {
+		return err
+	}
+
+	l, err := mpc.NewLogger(mpc.LLDebug, "")
+
+	if err != nil {
+		return err
+	}
+
+	dc, err := mpd.GetDataConnector("json", "db/temp.json", l)
+
+	if err != nil {
+		return err
+	}
+
+	for _, oldmovie := range oldmovies {
+		// convert old movies to new ones
+		newMovie := mpc.Movie{
+			Id:          oldmovie.Id,
+			Name:        oldmovie.Name,
+			Description: oldmovie.Description,
+			Remarks:     oldmovie.Remarks,
+			Duration:    oldmovie.Duration,
+			Rating:      oldmovie.Rating,
+			Removed:     oldmovie.Removed,
+			Approved:    oldmovie.Approved,
+			Poster:      oldmovie.Poster,
+		}
+
+		added, err := dc.GetCycle(oldmovie.CycleAddedId)
+		if err != nil {
+			return err
+		}
+		newMovie.CycleAdded = added
+
+		if oldmovie.CycleWatchedId != 0 {
+			watched, err := dc.GetCycle(oldmovie.CycleWatchedId)
+			if err != nil {
+				return err
+			}
+			newMovie.CycleWatched = watched
+		}
+
+		user, err := dc.GetUser(oldmovie.AddedBy)
+		if err != nil {
+			return err
+		}
+		newMovie.AddedBy = user
+
+		tags := []*mpc.Tag{}
+		for _, tagID := range oldmovie.Tags {
+			tag := dc.GetTag(tagID)
+			tags = append(tags, tag)
+		}
+		newMovie.Tags = tags
+
+		// convert strings to link structs and add them to the db
+		links := []*mpc.Link{}
+		for id, linkUrl := range oldmovie.Links {
+			link := mpc.Link{
+				Url:      linkUrl,
+				IsSource: id == 0,
+			}
+			ltype, err := link.DetermineLinkType()
+			if err != nil {
+				return err
+			}
+			link.Type = ltype
+
+			dc.AddLink(&link)
+			links = append(links, &link)
+		}
+		newMovie.Links = links
+
+		dc.AddMovie(&newMovie)
+	}
+
+	err = os.Rename("db/temp.json", jsonFilename)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/migrateLinks.go
+++ b/cmd/migrateLinks.go
@@ -122,23 +122,13 @@ func loadOldDB() error {
 		// convert strings to link structs and add them to the db
 		links := []*mpc.Link{}
 		for id, linkUrl := range oldmovie.Links {
-			link := mpc.Link{
-				Url:      linkUrl,
-				IsSource: id == 0,
-			}
-
-			err := link.ValidateLink()
+			link, err := mpc.NewLink(linkUrl, id)
 			if err != nil {
 				return err
 			}
 
-			err = link.DetermineLinkType()
-			if err != nil {
-				return err
-			}
-
-			dc.AddLink(&link)
-			links = append(links, &link)
+			dc.AddLink(link)
+			links = append(links, link)
 		}
 		newMovie.Links = links
 

--- a/cmd/migrateLinks.go
+++ b/cmd/migrateLinks.go
@@ -137,7 +137,7 @@ func loadOldDB() error {
 		}
 		newMovie.Links = links
 
-		dc.AddMovie(&newMovie)
+		dc.UpdateMovie(&newMovie)
 	}
 
 	err = os.Rename("db/temp.json", jsonFilename)

--- a/cmd/migrateLinks.go
+++ b/cmd/migrateLinks.go
@@ -61,7 +61,7 @@ func loadOldDB() error {
 
 	data, err = json.MarshalIndent(fullData, "", " ")
 
-	err = ioutil.WriteFile("db/temp.json", data, 666)
+	err = ioutil.WriteFile("db/temp.json", data, 0666)
 	if err != nil {
 		return err
 	}

--- a/cmd/migrateLinks.go
+++ b/cmd/migrateLinks.go
@@ -126,11 +126,16 @@ func loadOldDB() error {
 				Url:      linkUrl,
 				IsSource: id == 0,
 			}
-			ltype, err := link.DetermineLinkType()
+
+			err := link.ValidateLink()
 			if err != nil {
 				return err
 			}
-			link.Type = ltype
+
+			err = link.DetermineLinkType()
+			if err != nil {
+				return err
+			}
 
 			dc.AddLink(&link)
 			links = append(links, &link)

--- a/common/link.go
+++ b/common/link.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Link struct {
+	Id       int
+	IsSource bool
+	Type     string
+	Url      string
+}
+
+func (l Link) String() string {
+	return fmt.Sprintf("Link{Id: %v Url: %s Type: %s IsSource: %v}", l.Id, l.Url, l.Type, l.IsSource)
+}
+
+func (l Link) DetermineLinkType() (string, error) {
+	if strings.Contains(l.Url, "imdb") {
+		return "IMDb", nil
+	}
+	if strings.Contains(l.Url, "myanimelist") {
+		return "MyAnimeList", nil
+	}
+
+	return "Misc", nil
+}

--- a/common/link.go
+++ b/common/link.go
@@ -27,22 +27,23 @@ func (l *Link) ValidateLink() error {
 		if len(url) <= 8 {
 			// lets be stupid when the link is too short
 			if !strings.ContainsAny(url, "//") {
-				l.Url = "https://" + url
+				url = "https://" + url
 			}
 		} else {
 			// lets be smart when the link is long enough
 			// url[:8] ensures that we only look at the 8 first characters of the url -> where the protocol part should be
 			if !strings.Contains(url[:8], "//") {
-				l.Url = "https://" + url
+				url = "https://" + url
 			}
 		}
+		l.Url = url
 		return nil
 	}
 	return fmt.Errorf("Invalid link: %v", l.Url)
 }
 
 func stripRefFromLink(link string) string {
-	idx := strings.Index(link, "?ref")
+	idx := strings.Index(link, "/?")
 	if idx != -1 {
 		return link[:idx]
 	}

--- a/common/link.go
+++ b/common/link.go
@@ -16,13 +16,24 @@ func (l Link) String() string {
 	return fmt.Sprintf("Link{Id: %v Url: %s Type: %s IsSource: %v}", l.Id, l.Url, l.Type, l.IsSource)
 }
 
-func (l Link) DetermineLinkType() (string, error) {
+func (l *Link) ValidateLink() error {
+	url := l.Url
+	if !strings.Contains(url, "//") {
+		l.Url = "https://" + url
+	}
+	return nil
+}
+
+func (l *Link) DetermineLinkType() error {
 	if strings.Contains(l.Url, "imdb") {
-		return "IMDb", nil
+		l.Type = "IMDb"
+		return nil
 	}
 	if strings.Contains(l.Url, "myanimelist") {
-		return "MyAnimeList", nil
+		l.Type = "MyAnimeList"
+		return nil
 	}
 
-	return "Misc", nil
+	l.Type = "Misc"
+	return nil
 }

--- a/common/link.go
+++ b/common/link.go
@@ -13,6 +13,32 @@ type Link struct {
 	Url      string
 }
 
+func NewLink(link string, id int) (*Link, error) {
+	var source bool
+	if id == 0 {
+		source = true
+	} else {
+		source = false
+	}
+
+	ls := Link{
+		Url:      link,
+		IsSource: source,
+	}
+
+	err := ls.ValidateLink()
+	if err != nil {
+		return nil, err
+	}
+
+	err = ls.DetermineLinkType()
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
 func (l Link) String() string {
 	return fmt.Sprintf("Link{Id: %v Url: %s Type: %s IsSource: %v}", l.Id, l.Url, l.Type, l.IsSource)
 }

--- a/common/link.go
+++ b/common/link.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -16,12 +17,36 @@ func (l Link) String() string {
 	return fmt.Sprintf("Link{Id: %v Url: %s Type: %s IsSource: %v}", l.Id, l.Url, l.Type, l.IsSource)
 }
 
+var re_validLink = *regexp.MustCompile(`[a-zA-Z0-9:._\+]{1,256}\.[a-zA-Z0-9()]{1,6}[a-zA-Z0-9%_:\+.\/]*`)
+
 func (l *Link) ValidateLink() error {
 	url := l.Url
-	if !strings.Contains(url, "//") {
-		l.Url = "https://" + url
+	if re_validLink.MatchString(url) {
+		url = stripRefFromLink(url)
+
+		if len(url) <= 8 {
+			// lets be stupid when the link is too short
+			if !strings.ContainsAny(url, "//") {
+				l.Url = "https://" + url
+			}
+		} else {
+			// lets be smart when the link is long enough
+			// url[:8] ensures that we only look at the 8 first characters of the url -> where the protocol part should be
+			if !strings.Contains(url[:8], "//") {
+				l.Url = "https://" + url
+			}
+		}
+		return nil
 	}
-	return nil
+	return fmt.Errorf("Invalid link: %v", l.Url)
+}
+
+func stripRefFromLink(link string) string {
+	idx := strings.Index(link, "?ref")
+	if idx != -1 {
+		return link[:idx]
+	}
+	return link
 }
 
 func (l *Link) DetermineLinkType() error {

--- a/common/link.go
+++ b/common/link.go
@@ -26,17 +26,17 @@ func NewLink(link string, id int) (*Link, error) {
 		IsSource: source,
 	}
 
-	err := ls.ValidateLink()
+	err := ls.validateLink()
 	if err != nil {
 		return nil, err
 	}
 
-	err = ls.DetermineLinkType()
+	err = ls.determineLinkType()
 	if err != nil {
 		return nil, err
 	}
 
-	return nil, nil
+	return &ls, nil
 }
 
 func (l Link) String() string {
@@ -45,7 +45,7 @@ func (l Link) String() string {
 
 var re_validLink = *regexp.MustCompile(`[a-zA-Z0-9:._\+]{1,256}\.[a-zA-Z0-9()]{1,6}[a-zA-Z0-9%_:\+.\/]*`)
 
-func (l *Link) ValidateLink() error {
+func (l *Link) validateLink() error {
 	url := l.Url
 	if re_validLink.MatchString(url) {
 		url = stripRefFromLink(url)
@@ -76,7 +76,7 @@ func stripRefFromLink(link string) string {
 	return link
 }
 
-func (l *Link) DetermineLinkType() error {
+func (l *Link) determineLinkType() error {
 	if strings.Contains(l.Url, "imdb") {
 		l.Type = "IMDb"
 		return nil

--- a/common/movie.go
+++ b/common/movie.go
@@ -9,7 +9,7 @@ import (
 type Movie struct {
 	Id          int
 	Name        string
-	Links       []string
+	Links       []*Link
 	Description string
 	Remarks     string
 	Duration    string

--- a/common/util.go
+++ b/common/util.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -23,32 +22,6 @@ func FileExists(path string) bool {
 		return false
 	}
 	return true
-}
-
-var re_validLink = *regexp.MustCompile(`[a-zA-Z0-9:._\+]{1,256}\.[a-zA-Z0-9()]{1,6}[a-zA-Z0-9%_:\+.\/]*`)
-
-// verifyLinks checks each link for valid syntax and trims spaces.
-func VerifyLinks(links []string) ([]string, error) {
-	l := []string{}
-	for _, link := range links {
-		if re_validLink.Match([]byte(link)) {
-			link := stripRefFromLink(link)
-			l = append(l, link)
-		}
-	}
-	if len(l) == 0 {
-		return nil, fmt.Errorf("No valid links provided")
-	} else {
-		return l, nil
-	}
-}
-
-func stripRefFromLink(link string) string {
-	idx := strings.Index(link, "?ref")
-	if idx != -1 {
-		return link[:idx]
-	}
-	return link
 }
 
 var re_cleanNameA = *regexp.MustCompile(`[^a-zA-Z0-9 ]`)

--- a/data/connector.go
+++ b/data/connector.go
@@ -36,9 +36,11 @@ type DataConnector interface {
 	GetUser(id int) (*common.User, error)
 	GetActiveMovies() ([]*common.Movie, error)
 	GetTag(id int) *common.Tag
+	GetLink(id int) *common.Link
 
 	SearchMovieTitles(query string) ([]*common.Movie, error)
 	FindTag(name string) (int, error)
+	FindLink(url string) (int, error)
 
 	GetUserVotes(userId int) ([]*common.Movie, error)
 	GetUserMovies(userId int) ([]*common.Movie, error)
@@ -61,10 +63,12 @@ type DataConnector interface {
 	AddMovie(movie *common.Movie) (int, error)
 	AddUser(user *common.User) (int, error)
 	AddTag(tag *common.Tag) (int, error)
+	AddLink(link *common.Link) (int, error)
 
 	AddVote(userId, movieId int) error
 	DeleteVote(userId, movieId int) error
 	DeleteTag(tagId int)
+	DeleteLink(linkId int)
 	// Removes votes older than age
 	DecayVotes(age int) error
 

--- a/data/json.go
+++ b/data/json.go
@@ -16,7 +16,7 @@ import (
 type jsonMovie struct {
 	Id             int
 	Name           string
-	Links          []string
+	Links          []int
 	Description    string
 	Remarks        string
 	Duration       string
@@ -49,10 +49,10 @@ func (j *jsonConnector) newJsonMovie(movie *common.Movie) jsonMovie {
 		}
 	}
 
-	links := []string{}
+	links := []int{}
 	if movie.Links != nil {
 		for _, link := range movie.Links {
-			links = append(links, link.Url)
+			links = append(links, link.Id)
 		}
 	}
 
@@ -87,9 +87,9 @@ func (j *jsonConnector) newJsonMovie(movie *common.Movie) jsonMovie {
 	}
 
 	if movie.Links != nil {
-		links := []string{}
+		links := []int{}
 		for _, link := range movie.Links {
-			links = append(links, link.Url)
+			links = append(links, link.Id)
 		}
 		jm.Links = links
 	}
@@ -507,13 +507,7 @@ func (j *jsonConnector) movieFromJson(jMovie jsonMovie) *common.Movie {
 		tags = append(tags, j.GetTag(id))
 	}
 
-	for _, url := range jMovie.Links {
-		id, err := j.FindLink(url)
-		if err != nil {
-			j.l.Info("Could not find link id for url: %s\n Creating new link entry", url)
-			// FFS - i cannot automatically migrate old movies since that line causes a write after read anomaly -> deadlock
-			// j.AddLink(&common.Link{Url: url, Type: "Misc"})
-		}
+	for _, id := range jMovie.Links {
 		links = append(links, j.GetLink(id))
 	}
 
@@ -902,9 +896,9 @@ func (j *jsonConnector) DeleteLink(id int) {
 
 func (j *jsonConnector) nextLinkId() int {
 	highest := 0
-	for _, t := range j.Links {
-		if t.Id >= highest {
-			highest = t.Id
+	for _, l := range j.Links {
+		if l.Id >= highest {
+			highest = l.Id
 		}
 	}
 	return highest + 1

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/sessions v1.2.0
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/rivo/uniseg v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
 github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
+github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=

--- a/server.go
+++ b/server.go
@@ -658,35 +658,20 @@ func (s *Server) handleAutofill(data *dataAddMovie, w http.ResponseWriter, r *ht
 
 	// Convert links to structs
 	for id, link := range linkstrings {
-		var source bool
-		if id == 0 {
-			source = true
-		} else {
-			source = false
-		}
 
-		ls := common.Link{
-			Url:      link,
-			IsSource: source,
-		}
+		ls, err := common.NewLink(link, id)
 
-		err = ls.ValidateLink()
 		if err != nil {
-			s.l.Error(err.Error())
-			data.ErrorMessage = append(data.ErrorMessage, err.Error())
+			s.l.Error("Cannot add link")
+			data.ErrorMessage = append(data.ErrorMessage, "Could not add link: %v", err.Error())
 			data.ErrLinks = true
 		}
 
-		err = ls.DetermineLinkType()
-		if err != nil {
-			s.l.Error("unable to determine link type: %v", err)
-		}
-
 		if ls.IsSource {
-			sourcelink = &ls
+			sourcelink = ls
 		}
 
-		links = append(links, &ls)
+		links = append(links, ls)
 	}
 
 	// Check Remarks max length
@@ -1014,30 +999,16 @@ func (s *Server) handleFormfill(data *dataAddMovie, w http.ResponseWriter, r *ht
 
 	// Convert links to structs
 	for id, link := range linkstrings {
-		var source bool
-		if id == 0 {
-			source = true
-		} else {
-			source = false
-		}
 
-		ls := common.Link{
-			Url:      link,
-			IsSource: source,
-		}
+		ls, err := common.NewLink(link, id)
 
-		err = ls.ValidateLink()
 		if err != nil {
-			s.l.Error(err.Error())
-			data.ErrorMessage = append(data.ErrorMessage, err.Error())
+			s.l.Error("Cannot add link")
+			data.ErrorMessage = append(data.ErrorMessage, "Could not add link: %v", err.Error())
 			data.ErrLinks = true
 		}
 
-		err = ls.DetermineLinkType()
-		if err != nil {
-			s.l.Error("unable to determine link type: %v", err)
-		}
-		links = append(links, &ls)
+		links = append(links, ls)
 	}
 
 	// Check Remarks max length

--- a/server.go
+++ b/server.go
@@ -654,14 +654,6 @@ func (s *Server) handleAutofill(data *dataAddMovie, w http.ResponseWriter, r *ht
 		data.ErrLinks = true
 	}
 
-	// Validate links
-	linkstrings, err = common.VerifyLinks(linkstrings)
-	if err != nil {
-		s.l.Error(err.Error())
-		data.ErrorMessage = append(data.ErrorMessage, "Invalid link(s) given.")
-		data.ErrLinks = true
-	}
-
 	var sourcelink *common.Link
 
 	// Convert links to structs
@@ -677,9 +669,12 @@ func (s *Server) handleAutofill(data *dataAddMovie, w http.ResponseWriter, r *ht
 			Url:      link,
 			IsSource: source,
 		}
+
 		err = ls.ValidateLink()
 		if err != nil {
-			s.l.Error("unable to validate link url: %v", err)
+			s.l.Error(err.Error())
+			data.ErrorMessage = append(data.ErrorMessage, err.Error())
+			data.ErrLinks = true
 		}
 
 		err = ls.DetermineLinkType()
@@ -1017,14 +1012,6 @@ func (s *Server) handleFormfill(data *dataAddMovie, w http.ResponseWriter, r *ht
 		data.ErrLinks = true
 	}
 
-	// Validate links
-	linkstrings, err = common.VerifyLinks(linkstrings)
-	if err != nil {
-		s.l.Error(err.Error())
-		data.ErrorMessage = append(data.ErrorMessage, "Invalid link(s) given.")
-		data.ErrLinks = true
-	}
-
 	// Convert links to structs
 	for id, link := range linkstrings {
 		var source bool
@@ -1041,7 +1028,9 @@ func (s *Server) handleFormfill(data *dataAddMovie, w http.ResponseWriter, r *ht
 
 		err = ls.ValidateLink()
 		if err != nil {
-			s.l.Error("unable to validate link url: %v", err)
+			s.l.Error(err.Error())
+			data.ErrorMessage = append(data.ErrorMessage, err.Error())
+			data.ErrLinks = true
 		}
 
 		err = ls.DetermineLinkType()

--- a/server.go
+++ b/server.go
@@ -411,6 +411,14 @@ func (s *Server) handlerAddMovie(w http.ResponseWriter, r *http.Request) {
 				// Prepare a int for the id
 				var movieId int
 
+				for _, link := range movie.Links {
+					id, err := s.data.AddLink(link)
+					if err != nil {
+						s.l.Debug("link error: %v", err)
+					}
+					link.Id = id
+				}
+
 				movieId, err = s.data.AddMovie(movie)
 				if err != nil {
 					data.ErrTitle = true // For now we enable the title flag

--- a/server.go
+++ b/server.go
@@ -677,8 +677,12 @@ func (s *Server) handleAutofill(data *dataAddMovie, w http.ResponseWriter, r *ht
 			Url:      link,
 			IsSource: source,
 		}
+		err = ls.ValidateLink()
+		if err != nil {
+			s.l.Error("unable to validate link url: %v", err)
+		}
 
-		ls.Type, err = ls.DetermineLinkType()
+		err = ls.DetermineLinkType()
 		if err != nil {
 			s.l.Error("unable to determine link type: %v", err)
 		}
@@ -1035,7 +1039,12 @@ func (s *Server) handleFormfill(data *dataAddMovie, w http.ResponseWriter, r *ht
 			IsSource: source,
 		}
 
-		ls.Type, err = ls.DetermineLinkType()
+		err = ls.ValidateLink()
+		if err != nil {
+			s.l.Error("unable to validate link url: %v", err)
+		}
+
+		err = ls.DetermineLinkType()
 		if err != nil {
 			s.l.Error("unable to determine link type: %v", err)
 		}

--- a/templates/movie-info.html
+++ b/templates/movie-info.html
@@ -36,7 +36,15 @@
     <p>Watched: {{.Movie.CycleWatched.EndedString}}</p>
     {{end}}
     <div>Added by: {{if .Movie.AddedBy}} {{.Movie.AddedBy.Name}} {{else}} somebody {{end}}</div>
-    {{if .Movie.Links}}<div><ul>{{range .Movie.Links}}<li><a href="{{.}}">{{.}}</a></li>{{end}}</ul></div>{{end}}
+	{{if .Movie.Links}}<div>
+		{{if eq (len .Movie.Links) 1 }}
+			<a href="{{(index .Movie.Links 0).Url}}">Visit {{(index .Movie.Links 0).Type}} for more Information</a>
+		{{else}}
+			<a href="{{(index .Movie.Links 0).Url}}">Visit {{(index .Movie.Links 0).Type}} for more Information</a>
+			<p>Other Links:</p>
+		<ul>{{range (slice .Movie.Links 1)}}<li><a href="{{.Url}}">{{.Url}}</a></li>{{end}}</ul>
+		{{end}}
+	</div>{{end}}
     <div>
         {{if .Movie.Votes}}
         <p>Votes: {{len .Movie.Votes}}</p>


### PR DESCRIPTION
This PR closes #69 . (Sorry for the massive PR again)

I added a new file common/link.go for the new Link struct. This struct resembles the idea discussed in #69 :
```
type Link struct {
    Id       int
    Type     string
    Url      string
    IsSource bool
}
```
This struct also got a new Function called `l.DetermineType() string {...}` which looks the URL of the link struct and tries to determine the origin (IMDb or MyAnimeList) and returns the determined type.

I also added 4 new functions to the connector interface, namely AddTag, FindTag, GetTag, DeleteTag for the usual CRUD functionality. Of course i also implemented these Functions in the JSON Connector ready to use.
I also adapted the Movie struct to work with the Link struct as well as all the logic in `server.go`.

For Backwards compatibility of the database i also provide a migration Script `cmd/migrateLinks.go` which parses the data json file from the previous versions and converts the old Movie objects to new ones which use the Link struct described above.
For my own sanity i used an external library to not go insane trying to parse the old json format (i really hate the way go handles json in the standard library).
In a nutshell the script parses the old json data - deletes the movie map after saving it into ram and creates a temporary file. Afterwards the dataconnector is used to open this temporary file and add the new movies based on the old movies while also populating the new Link map.

Lastly i adapted the movie-info.html template to make use of the new fields introduced with the Link struct.
![image](https://user-images.githubusercontent.com/23438606/94498410-5ab20500-01fa-11eb-9070-ba7d789cb566.png)
