### PR TITLE
Cleaning up mobile link fragments from inserted links #91

### DIFF
--- a/common/link.go
+++ b/common/link.go
@@ -47,9 +47,8 @@ var re_validLink = *regexp.MustCompile(`[a-zA-Z0-9:._\+]{1,256}\.[a-zA-Z0-9()]{1
 
 func (l *Link) validateLink() error {
 	url := l.Url
+	url = cleanupLink(url)
 	if re_validLink.MatchString(url) {
-		url = stripRefFromLink(url)
-		url = stripMobileFromLink(url)
 
 		if len(url) <= 8 {
 			// lets be stupid when the link is too short
@@ -69,18 +68,20 @@ func (l *Link) validateLink() error {
 	return fmt.Errorf("Invalid link: %v", l.Url)
 }
 
-func stripRefFromLink(link string) string {
-	idx := strings.Index(link, "/?")
-	if idx != -1 {
-		return link[:idx]
-	}
-	return link
+var replacements = map[string]string{
+	"m.imdb.com": "imdb.com",
 }
 
-// for now we just replace it for imdb, if we need others we need to adapt that
-// is it stupid, YES, does it work, i guess? do i have a better idea, no
-func stripMobileFromLink(link string) string {
-	return strings.Replace(link, "m.imdb.com", "imdb.com", 1)
+func cleanupLink(link string) string {
+	idx := strings.Index(link, "/?")
+	if idx != -1 {
+		link = link[:idx]
+	}
+	for from, to := range replacements {
+		link = strings.Replace(link, from, to, 1)
+	}
+
+	return link
 }
 
 func (l *Link) determineLinkType() error {

--- a/common/link.go
+++ b/common/link.go
@@ -49,6 +49,7 @@ func (l *Link) validateLink() error {
 	url := l.Url
 	if re_validLink.MatchString(url) {
 		url = stripRefFromLink(url)
+		url = stripMobileFromLink(url)
 
 		if len(url) <= 8 {
 			// lets be stupid when the link is too short
@@ -74,6 +75,12 @@ func stripRefFromLink(link string) string {
 		return link[:idx]
 	}
 	return link
+}
+
+// for now we just replace it for imdb, if we need others we need to adapt that
+// is it stupid, YES, does it work, i guess? do i have a better idea, no
+func stripMobileFromLink(link string) string {
+	return strings.Replace(link, "m.imdb.com", "imdb.com", 1)
 }
 
 func (l *Link) determineLinkType() error {


### PR DESCRIPTION
This function is used to clean up mobile modifiers in (for now) imdb
links.
I created the function to later adapt it for more urls (now it just uses
strings.Replace).
This fixes #91