### PR TITLE
Implementation for multi episode time limits (#88)

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -385,6 +385,7 @@ func (s *Server) handlerAdminConfig(w http.ResponseWriter, r *http.Request) {
 			configValue{Key: ConfigMaxDescriptionLength, Default: DefaultMaxDescriptionLength, Type: ConfigInt},
 			configValue{Key: ConfigMaxLinkLength, Default: DefaultMaxLinkLength, Type: ConfigInt},
 			configValue{Key: ConfigMaxRemarksLength, Default: DefaultMaxRemarksLength, Type: ConfigInt},
+			configValue{Key: ConfigMaxMultEpLength, Default: DefaultMaxMultEpLength, Type: ConfigInt},
 
 			configValue{Key: ConfigUnlimitedVotes, Default: DefaultUnlimitedVotes, Type: ConfigBool},
 		},

--- a/server.go
+++ b/server.go
@@ -923,7 +923,17 @@ func (s *Server) handleJikan(data *dataAddMovie, w http.ResponseWriter, r *http.
 		return nil, fmt.Errorf("Error while retriving config value 'JikanMaxEpisodes':\n %v", err)
 	}
 
-	sourceAPI := jikan{id: id, l: s.l, excludedTypes: bannedTypes, maxEpisodes: maxEpisodes}
+	maxDuration, err := s.data.GetCfgInt(ConfigMaxMultEpLength, DefaultMaxMultEpLength)
+
+	if err != nil {
+		s.doError(
+			http.StatusInternalServerError,
+			"something went wrong :C",
+			w, r)
+		return nil, fmt.Errorf("Error while retriving config value 'MaxMultEpLength':\n %v", err)
+	}
+
+	sourceAPI := jikan{id: id, l: s.l, excludedTypes: bannedTypes, maxEpisodes: maxEpisodes, maxDuration: maxDuration}
 
 	// Request data from API
 	results, err := getMovieData(&sourceAPI)

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ const (
 	DefaultMaxDescriptionLength int = 1000
 	DefaultMaxLinkLength        int = 500 // length of all links combined
 	DefaultMaxRemarksLength     int = 200
+	DefaultMaxMultEpLength      int = 120 // length of multiple episode entries in minutes
 )
 
 // configuration keys
@@ -60,6 +61,7 @@ const (
 	ConfigMaxDescriptionLength string = "MaxDescriptionLength"
 	ConfigMaxLinkLength        string = "MaxLinkLength"
 	ConfigMaxRemarksLength     string = "MaxRemarksLength"
+	ConfigMaxMultEpLength      string = "ConfigMaxMultEpLength"
 )
 
 type Options struct {


### PR DESCRIPTION
This PR adds the ability to set a multi episode time limit for mal entries that have multiple episodes.
The idea behind this was to enable watching i.e. OVAs that have only a low amount of episodes and therefore having a shorter overall runtime compared to a normal anime.

This PR intentionally omits this feature for imdb entries since series are not supported anyways (see #19 ).

Fixes #88