### PR TITLE
OAuth Error gives user feedback

### DIFF
--- a/web/handlersAuth.go
+++ b/web/handlersAuth.go
@@ -492,8 +492,11 @@ func (s *webServer) handlerTwitchOAuthCallback(w http.ResponseWriter, r *http.Re
 			}
 		} else {
 			s.l.Info("The provided Oauth login is already used")
-			http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
-			return
+
+			s.callbackError = callbackError{
+				user:    user.Id,
+				message: "The provided Oauth login is already used",
+			}
 		}
 		http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
 		return
@@ -762,8 +765,11 @@ func (s *webServer) handlerDiscordOAuthCallback(w http.ResponseWriter, r *http.R
 			}
 		} else {
 			s.l.Info("The provided Oauth login is already used")
-			http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
-			return
+
+			s.callbackError = callbackError{
+				user:    user.Id,
+				message: "The provided Oauth login is already used",
+			}
 		}
 		http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
 		return
@@ -1031,8 +1037,11 @@ func (s *webServer) handlerPatreonOAuthCallback(w http.ResponseWriter, r *http.R
 			}
 		} else {
 			s.l.Info("The provided Oauth login is already used")
-			http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
-			return
+
+			s.callbackError = callbackError{
+				user:    user.Id,
+				message: "The provided Oauth login is already used",
+			}
 		}
 		http.Redirect(w, r, "/user", http.StatusTemporaryRedirect)
 		return

--- a/web/pageUser.go
+++ b/web/pageUser.go
@@ -58,6 +58,8 @@ func (s *webServer) handlerPageUser(w http.ResponseWriter, r *http.Request) {
 		HasDiscord bool
 		HasPatreon bool
 
+		CallbackError string
+
 		ActiveVotes    []*models.Movie
 		WatchedVotes   []*models.Movie
 		AddedMovies    []*models.Movie
@@ -82,6 +84,15 @@ func (s *webServer) handlerPageUser(w http.ResponseWriter, r *http.Request) {
 		ActiveVotes:  activeVotes,
 		WatchedVotes: watchedVotes,
 		AddedMovies:  addedMovies,
+	}
+
+	if s.callbackError.message != "" {
+		if user.Id == s.callbackError.user {
+			data.CallbackError = s.callbackError.message
+
+			s.callbackError.user = 0
+			s.callbackError.message = ""
+		}
 	}
 
 	twitchAuth, err := s.backend.GetTwitchOauthEnabled()

--- a/web/server.go
+++ b/web/server.go
@@ -26,6 +26,11 @@ type Options struct {
 	Debug  bool   // debug logging to console
 }
 
+type callbackError struct {
+	user    int
+	message string
+}
+
 type webServer struct {
 	templates map[string]*template.Template
 	s         *http.Server
@@ -35,7 +40,8 @@ type webServer struct {
 	cookies      *sessions.CookieStore
 	passwordSalt string
 
-	l *logger.Logger
+	callbackError callbackError
+	l             *logger.Logger
 }
 
 func New(options Options, backend logic.Logic, log *logger.Logger) (*webServer, error) {

--- a/web/templates/account.html
+++ b/web/templates/account.html
@@ -110,6 +110,10 @@
         </div>
       {{end}}
 		</div>
+      {{if .CallbackError}}
+        </br>
+        <div>{{.CallbackError}}</div>
+      {{end}}
 	{{end}}
 
 	</br>


### PR DESCRIPTION
This fixes #118.

I created a new struct 
```go
type callbackError struct {
    user         int
    message string
}
```
in the web package and added it to the webServer struct.

This new struct is used to "transmit" errors from the oauth callbacks to the frontend (a simple return would not work since the callback is executed by the routing and has no place to return the error to).

For further implementation details see the commit messages.