### PR TITLE
Improve form error visiblity

### DIFF
--- a/web/pageAddMovie.go
+++ b/web/pageAddMovie.go
@@ -116,7 +116,6 @@ func (s *webServer) handlerPageAddMovie(w http.ResponseWriter, r *http.Request) 
 		MaxLinkLength        int
 		MaxRemarksLength     int
 
-		HasError  bool
 		FileError error
 	}{
 		dataPageBase: s.newPageBase("Add Movie", w, r),
@@ -160,7 +159,6 @@ func (s *webServer) handlerPageAddMovie(w http.ResponseWriter, r *http.Request) 
 			return
 		} else {
 			data.Fields = fields
-			data.HasError = hasError
 		}
 	}
 	if err := s.executeTemplate(w, "addmovie", data); err != nil {

--- a/web/static/css/site.css
+++ b/web/static/css/site.css
@@ -323,6 +323,7 @@ margin-left: 5px;
 .movieInput {
     display: flex;
     flex-direction: column;
+    margin-bottom: 18px;
 }
 
 .movieInput textarea,

--- a/web/static/css/site.css
+++ b/web/static/css/site.css
@@ -287,25 +287,18 @@ margin-left: 5px;
 }
 
 .warningIcon {
-    color: #FF0000
+    margin-right: 8px;
 }
 
 .errorPopup {
-    display: none;
-}
-
-i:hover + .errorPopup {
-    display: block;
-    position: absolute;
-    z-index: 200;
-    width: 390px;
+    margin: 4px 0;
     background-color: #ff8181;
     border-left: inset;
     border-color: red;
     border-width: thick;
     padding: 3px;
     padding-left: 0.5em;
-    color: #363637;    
+    color: #363637;
 }
 
 .voteButton {

--- a/web/templates/add-movie.html
+++ b/web/templates/add-movie.html
@@ -4,15 +4,16 @@
 
 {{define "body"}}
 <form method="POST" action="/add" enctype="multipart/form-data">
-    {{if .HasError}}<div class="errorMessage">The input contained errors, see the highlighted fields for more information.</div>{{end}}
     <div id="addMovieForm">
 		{{if .FormfillEnabled}}
             <div class="movieInput">
                 <div class="movieHeader">
-                    {{if (index .Fields "Title")}}{{if (index .Fields "Title").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "Title").Error}}</div>{{end}}{{end}}
                     <label for="Title">Movie Title (max. {{.MaxTitleLength}} characters)</label>
                     <div class="maxlength_indicator" data-type="length" data-name="Title"></div>
                 </div>
+                {{if and (index .Fields "Title") (index .Fields "Title").Error}}
+                    <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "Title").Error}}</div>
+                {{end}}
                 <div>
                     <textarea name="Title" id="Title" maxlength="{{.MaxTitleLength}}">{{if (index .Fields "Title")}}{{if (index .Fields "Title").Value}}{{ (index .Fields "Title").Value}}{{end}}{{end}}</textarea>
                 </div>
@@ -20,30 +21,35 @@
 
             <div class="movieInput">
                 <div class="movieHeader">
-                    {{if (index .Fields "Description")}}{{if (index .Fields "Description").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "Description").Error}}</div>{{end}}{{end}}
                     <label for="Description">Description (max. {{.MaxDescriptionLength}} characters)</label>
                     <div class="maxlength_indicator" data-type="length" data-name="Description"></div>
                 </div>
+                {{if and (index .Fields "Description") (index .Fields "Description").Error}}
+                    <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "Description").Error}}</div>
+                {{end}}
                 <div>
                     <textarea name="Description" id="Description" maxlength="{{.MaxDescriptionLength}}">{{if (index .Fields "Description")}}{{if (index .Fields "Description").Value}}{{( index .Fields "Description").Value}}{{end}}{{end}}</textarea>
                 </div>
             </div>
-
             <div class="movieInput">
                 <div class="movieHeader">
-                    {{if (index .Fields "Links")}}{{if (index .Fields "Links").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "Links").Error}}</div>{{end}}{{end}}
                     <label for="Links">Referencelinks (max. {{.MaxLinkLength}} characters per Link)</label>
                     <div class="maxlength_indicator" data-type="link" data-name="Links" data-link-length={{.MaxLinkLength}}></div>
                 </div>
+                {{if and (index .Fields "Links") (index .Fields "Links").Error}}
+                    <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "Links").Error}}</div>
+                {{end}}
                 <div>
                     <textarea name="Links" id="Links">{{if (index .Fields "Links")}}{{if (index .Fields "Links").Value}}{{ (index .Fields "Links").Value}}{{end}}{{end}}</textarea>
                 </div>
             </div>
             <div class="movieInput">
                 <div class="movieHeader">
-                    {{if (index .Fields "PosterFile")}}{{if (index .Fields "PosterFile").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "PosterFile").Error}}</div>{{end}}{{end}}
                     <label for="PosterFile">Poster Image</label>
                 </div>
+                {{if and (index .Fields "PosterFile") (index .Fields "PosterFile").Error}}
+                    <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "PosterFile").Error}}</div>
+                {{end}}
                 <div>
                     <input type="file" name="PosterFile" id="PosterFile" accept="image/*"/>
                 </div>
@@ -51,9 +57,11 @@
             {{ if .AutofillEnabled }}
                 <div class="movieInput">
                     <div class="movieHeader">
-                        {{if (index .Fields "AutofillBox")}}{{if (index .Fields "AutofillBox").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "AutofillBox").Error}}</div>{{end}}{{end}}
                         <label for="AutofillBox">Autofill Data with the provided Link</label>
                     </div>
+                    {{if and (index .Fields "AutofillBox") (index .Fields "AutofillBox").Error}}
+                        <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "AutofillBox").Error}}</div>
+                    {{end}}
                     <div>
                         <input type="checkbox" name="AutofillBox" id="AutofillBox" {{if (index .Fields "AutofillBox")}}{{if eq ((index .Fields "AutofillBox").Value) "on"}}value="on"{{end}}{{end}}/>
                     </div>
@@ -65,10 +73,12 @@
         <input type="hidden" name="AutofillBox" value="on" />
         <div class="movieInput">
             <div class="movieHeader">
-                {{if (index .Fields "Links")}}{{if (index .Fields "Links").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "Links").Error}}</div>{{end}}{{end}}
                 <label for="Links">Enter IMDB or MyAnimeList link for a movie to add (max. {{.MaxLinkLength}} characters per Link):</label>
                 <div class="maxlength_indicator" data-type="link" data-name="Links" data-link-length={{.MaxLinkLength}}></div>
             </div>
+            {{if and (index .Fields "Links") (index .Fields "Links").Error}}
+                <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "Links").Error}}</div>
+            {{end}}
             <div>
                 <textarea name="Links" id="Links">{{if (index .Fields "Links")}}{{if (index .Fields "Links").Value}}{{(index .Fields "Links").Value}}{{end}}{{end}}</textarea>
             </div>
@@ -77,10 +87,12 @@
 
 		<div class="movieInput">
             <div class="movieHeader">
-                {{if (index .Fields "Remarks")}}{{if (index .Fields "Remarks").Error}}<i class='fas fa-exclamation-triangle warningIcon'></i><div class="errorPopup">{{(index .Fields "Remarks").Error}}</div>{{end}}{{end}}
                 <label class="RemarksLabel" for="Remarks">Enter your remarks here (max. {{.MaxRemarksLength}} characters):</label>
                 <div class="maxlength_indicator" data-type="length" data-name="Remarks"></div>
             </div>
+            {{if and (index .Fields "Remarks") (index .Fields "Remarks").Error}}
+                <div class="errorPopup"><i class='fas fa-exclamation-triangle warningIcon'></i>{{(index .Fields "Remarks").Error}}</div>
+            {{end}}
             <div>
                 <textarea name="Remarks" id="Remarks" maxlength="{{.MaxRemarksLength}}">{{ if (index .Fields "Remarks")}}{{if (index .Fields "Remarks").Value}}{{(index .Fields "Remarks").Value}}{{end}}{{end}}</textarea>
             </div>


### PR DESCRIPTION
The errors for the Add Movies page require the user to hover each one to see what the error is and, from what I've seen, they are difficult to hover and do not work most of the time.

This will show all errors by default without the need to hover them, right below the field's title. I also added spacing to make the form titles easier to read.

Pictures for comparison:
![errors-before](https://user-images.githubusercontent.com/6940264/198210386-a6477c75-302e-4c8f-b41b-509a74ade022.png)
![errors-after](https://user-images.githubusercontent.com/6940264/198210402-40806123-0042-4599-adf8-32d22f5cda05.png)
